### PR TITLE
move read and write

### DIFF
--- a/nwrapper/ngraph/runtime/parameterized_tensor_view.cpp
+++ b/nwrapper/ngraph/runtime/parameterized_tensor_view.cpp
@@ -29,8 +29,6 @@ static void declareParameterizedTensorView(py::module & mod, std::string const &
     using PyClass = py::class_<Class, std::shared_ptr<Class>, TensorView>;
 
     PyClass cls(mod, ("ParameterizedTensorView" + suffix).c_str());
-    cls.def("write", (void (Class::*) (const void*, size_t, size_t)) &Class::write);
-    cls.def("read", &Class::read);
 }
 
 }

--- a/nwrapper/ngraph/runtime/tensor_view.cpp
+++ b/nwrapper/ngraph/runtime/tensor_view.cpp
@@ -26,6 +26,8 @@ PYBIND11_MODULE(TensorView, mod) {
 
     py::class_<Value, std::shared_ptr<Value>> value(mod, "Value");
     py::class_<TensorView, std::shared_ptr<TensorView>, Value> tensorView(mod, "TensorView");
+    tensorView.def("write", (void (TensorView::*) (const void*, size_t, size_t)) &TensorView::write);
+    tensorView.def("read", &TensorView::read);
 }
 
 }}  // ngraph


### PR DESCRIPTION
The C++ code defines read and write in TensorView (not in a subclass). We should do the same.