### PR TITLE
Developer friendly ngraph API

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,0 +1,46 @@
+# ----------------------------------------------------------------------------
+# Copyright 2018 Nervana Systems Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+import numpy as np
+import ngraph as ng
+
+shape = [2, 2]
+A = ng.parameter(shape, name='A')
+B = ng.parameter(shape, name='B')
+C = ng.parameter(shape, name='C')
+# >>> print(A)
+# <Parameter: 'A'>
+
+model = (A + B) * C
+# >>> print(model)
+# <Node: 'Multiply_6'>
+
+runtime = ng.runtime('NGVM')
+# >>> print(runtime)
+# <Runtime: Manager='NGVM'>
+
+computation = runtime.computation(model, A, B, C)
+# >>> print(computation)
+# <Computation: Multiply_6(A, B, C)>
+
+value_a = np.array([[1, 2], [3, 4]], dtype=np.float32)
+value_b = np.array([[5, 6], [7, 8]], dtype=np.float32)
+value_c = np.array([[9, 10], [11, 12]], dtype=np.float32)
+
+result = computation(value_a, value_b, value_c)
+# >>> print(result)
+# [[ 54.  80.]
+#  [110. 144.]]
+print('Result = ', result)

--- a/ngraph/__init__.py
+++ b/ngraph/__init__.py
@@ -1,0 +1,18 @@
+# ----------------------------------------------------------------------------
+# Copyright 2018 Nervana Systems Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+"""ngraph module namespace, exposing factory functions for all ops and other classes"""
+
+from ngraph.ops import parameter
+from ngraph.runtime import runtime

--- a/ngraph/exceptions.py
+++ b/ngraph/exceptions.py
@@ -1,0 +1,23 @@
+# ----------------------------------------------------------------------------
+# Copyright 2018 Nervana Systems Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+"""ngraph exceptions hierarchy. All exceptions are descendants of NgraphError"""
+
+
+class NgraphError(Exception):
+    pass
+
+
+class UserInputError(NgraphError):
+    pass

--- a/ngraph/input_validation.py
+++ b/ngraph/input_validation.py
@@ -1,0 +1,33 @@
+# ----------------------------------------------------------------------------
+# Copyright 2018 Nervana Systems Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Helper functions for validating user input."""
+
+import logging
+from typing import Iterable
+
+from ngraph.exceptions import UserInputError
+
+log = logging.getLogger(__file__)
+
+
+def assert_list_of_ints(value_list: Iterable[int], message: str) -> None:
+    try:
+        for value in value_list:
+            if not isinstance(value, int):
+                raise TypeError
+    except TypeError:
+        log.warning(message)
+        raise UserInputError(message, value_list)

--- a/ngraph/ops.py
+++ b/ngraph/ops.py
@@ -1,0 +1,31 @@
+# ----------------------------------------------------------------------------
+# Copyright 2018 Nervana Systems Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Factory functions for all ngraph ops."""
+
+import numpy as np
+
+from nwrapper.ngraph.ops.Parameter import Parameter
+
+from ngraph.input_validation import assert_list_of_ints
+from ngraph.types import get_element_type, py_numeric_type
+from ngraph.utils import nameable_op
+
+
+@nameable_op
+def parameter(shape, dtype: py_numeric_type = np.float32, name: str=None) -> Parameter:
+    assert_list_of_ints(shape, 'Parameter shape must be a list of integer values.')
+    element_type = get_element_type(dtype)
+    return Parameter(element_type, shape)

--- a/ngraph/runtime.py
+++ b/ngraph/runtime.py
@@ -1,0 +1,92 @@
+# ----------------------------------------------------------------------------
+# Copyright 2018 Nervana Systems Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+"""Provide a layer of abstraction for the ngraph++ runtime environment."""
+import numpy as np
+
+import nwrapper.ngraph.Util as Util
+import nwrapper.ngraph.types.TraitedType as TraitedType
+import nwrapper.ngraph.types.TensorViewType as TensorViewType
+import nwrapper.ngraph.Node as Node
+import nwrapper.ngraph.Function as Function
+import nwrapper.ngraph.runtime.Manager as Manager
+from nwrapper.ngraph.ops.Parameter import Parameter
+
+from ngraph.types import py_numeric_type
+
+
+def runtime(manager_name: str='NGVM') -> 'Runtime':
+    """Helper factory to create a Runtime object.
+
+    Use signature to parametrize runtime as needed."""
+    return Runtime(manager_name)
+
+
+class Runtime:
+    """Represents the ngraph++ runtime environment."""
+
+    def __init__(self, manager_name: str) -> None:
+        self.manager_name = manager_name
+        self.manager = Manager.Manager.get(manager_name)
+        self.backend = self.manager.allocate_backend()
+
+    def __repr__(self):
+        return '<Runtime: Manager=\'{}\'>'.format(self.manager_name)
+
+    def computation(self, node: Node, *inputs: py_numeric_type) -> 'Computation':
+        return Computation(self, node, *inputs)
+
+
+class Computation:
+    """ngraph callable computation object"""
+
+    def __init__(self, runtime: Runtime, node: Node, *parameters: Parameter) -> None:
+        self.runtime = runtime
+        self.node = node
+        self.parameters = parameters
+        self.tensor_views = []
+        for parameter in parameters:
+            shape = parameter.get_shape()
+            element_type = TraitedType.TraitedTypeF.element_type()  # @TODO: get from input
+            self.tensor_views.append(runtime.backend.make_primary_tensor_view(element_type, shape))
+
+    def __repr__(self) -> str:
+        params_string = ', '.join([param.name for param in self.parameters])
+        return '<Computation: {}({})>'.format(self.node.name, params_string)
+
+    def __call__(self, *input_values: py_numeric_type) -> py_numeric_type:
+        """This is a quick and dirty implementation of the logic needed to calculate and return
+        a value of the computation."""
+        for tensor_view, value in zip(self.tensor_views, input_values):
+            if not type(value) == np.ndarray:
+                value = np.array(value)
+            tensor_view.write(Util.numpy_to_c(value), 0, 16)
+
+        result_element_type = TraitedType.TraitedTypeF.element_type()  # @TODO: get from self.node
+        result_shape = [2, 2]  # @TODO: get from self.node
+
+        result = self.runtime.backend.make_primary_tensor_view(result_element_type, result_shape)
+        result_arr = np.array([0, 0, 0, 0], dtype=np.float32)
+        result.write(Util.numpy_to_c(result_arr), 0, 16)
+
+        value_type = TensorViewType.TensorViewType(result_element_type, result_shape)
+        function = Function.Function(self.node, value_type, self.parameters, 'test')
+        external = self.runtime.manager.compile(function)
+
+        cf = self.runtime.backend.make_call_frame(external)
+        cf.call(self.tensor_views, [result])
+
+        result.read(Util.numpy_to_c(result_arr), 0, 16)
+        result_arr = result_arr.reshape(result_shape)
+        return result_arr

--- a/ngraph/types.py
+++ b/ngraph/types.py
@@ -1,0 +1,29 @@
+# ----------------------------------------------------------------------------
+# Copyright 2018 Nervana Systems Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+"""Functions related to converting between Python and numpy types and ngraph types"""
+from typing import Union
+
+import numpy as np
+
+import nwrapper.ngraph.types.TraitedType as TraitedType
+
+py_numeric_type = Union[int, float, np.ndarray]
+
+
+def get_element_type(dtype: py_numeric_type):
+    """Return an ngraph element type for a Python type or numpy.dtype."""
+    # @TODO: Map all types
+    element_type = TraitedType.TraitedTypeF.element_type()
+    return element_type

--- a/ngraph/utils.py
+++ b/ngraph/utils.py
@@ -1,0 +1,28 @@
+# ----------------------------------------------------------------------------
+# Copyright 2018 Nervana Systems Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+"""Factor related functions out to separate files"""
+
+from functools import wraps
+from typing import Callable
+
+
+def nameable_op(op_factory_function: Callable) -> Callable:
+    @wraps(op_factory_function)
+    def wrapper(*args, **kwds):
+        op = op_factory_function(*args, **kwds)
+        if 'name' in kwds:
+            op.name = kwds['name']
+        return op
+    return wrapper

--- a/nwrapper/ngraph/node.cpp
+++ b/nwrapper/ngraph/node.cpp
@@ -28,6 +28,11 @@ PYBIND11_MODULE(Node, mod) {
 
     py::class_<Node, std::shared_ptr<Node>> node(mod, "Node");
  
+    node.def("__repr__", [](const Node &self) {
+        std::string class_name = py::cast(self).get_type().attr("__name__").cast<std::string>();
+        return "<" + class_name + ": '" + self.get_name() + "'>";
+    });
+
     node.def("__add__", [](const std::shared_ptr<ngraph::Node>& a, const std::shared_ptr<ngraph::Node> b) {
                 return a + b;
                }, py::is_operator());
@@ -43,6 +48,10 @@ PYBIND11_MODULE(Node, mod) {
     node.def("get_shape", &Node::get_shape);
     node.def("get_value_type", (std::shared_ptr<const ValueType> (Node::*)()) &Node::get_value_type);
     node.def("get_value_type", (const std::shared_ptr<const ValueType> (Node::*)() const) &Node::get_value_type);
+
+    node.def_property_readonly("shape", &Node::get_shape);
+
+    node.def_property("name", &Node::get_name, &Node::set_name);
 }
 
 }  // ngraph

--- a/nwrapper/ngraph/ops/parameter.cpp
+++ b/nwrapper/ngraph/ops/parameter.cpp
@@ -29,7 +29,7 @@ PYBIND11_MODULE(Parameter, mod) {
     py::class_<op::Parameter, std::shared_ptr<op::Parameter>, Node> parameter(mod, "Parameter");
 
     parameter.def(py::init<const ngraph::element::Type&, const ngraph::Shape& >());
-    parameter.def("description", &op::Parameter::description);
+    parameter.def_property_readonly("description", &op::Parameter::description);
 }
 
 }  // ngraph


### PR DESCRIPTION
Ideas:

* single, clean namespace `import ngraph as ng`
* a helper function such as `ng.parameter` for each op
* abstract the `Runtime` environment away from the user as much as possible
* user-friendly `__repr__` for every object
* `nameable_op` decorator - each node can be given a name
* transparent, on-the-fly conversion from `np.ndarrays` to ngraph++ types
* accept `np.ndarrays`, but also simple Python number types for computation
* validate user input to every function e.g. `assert_list_of_ints`
* create and use a hierarchy of ngraph-specific exceptions
* liberally use `log.debug`, `log.info`, `log.warning`, etc.
* use pybind11 `def_property`, `def_property_readonly`, etc. for properties instead of getters (`.shape` instead of `.get_shape()`)
* `Computation` class would need to be ironed out
* nice-to-have: use mypy type annotations