### PR TITLE
API - Extend Node class to support binary operators

### DIFF
--- a/ngraph_api/ops.py
+++ b/ngraph_api/ops.py
@@ -120,6 +120,15 @@ def equal(left_node, right_node, name=None):  # type: (NodeInput, NodeInput, str
     return Equal(left_node, right_node)
 
 
+# Extend Node class to support binary operators
+Node.__mul__ = multiply
+Node.__div__ = divide
+Node.__sub__ = subtract
+Node.__add__ = add
+Node.__eq__ = equal
+Node.__truediv__ = divide
+
+
 @binary_op
 def minimum(left_node, right_node, name=None):  # type: (NodeInput, NodeInput, str) -> Node
     """Return node which applies the minimum operation to input nodes elementwise."""

--- a/test/ngraph_api/test_ops_binary.py
+++ b/test/ngraph_api/test_ops_binary.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ******************************************************************************
+import operator
 
 import numpy as np
 import pytest
@@ -68,6 +69,54 @@ def test_binary_op_with_scalar(ng_api_helper, numpy_function):
     parameter_a = ng.parameter(shape, name='A', dtype=np.float32)
 
     model = ng_api_helper(parameter_a, value_b)
+    computation = runtime.computation(model, parameter_a)
+
+    result = computation(value_a)
+    expected = numpy_function(value_a, value_b)
+    assert np.allclose(result, expected)
+
+
+@pytest.mark.parametrize('operator,numpy_function', [
+    (operator.add, np.add),
+    (operator.mul, np.multiply),
+    (operator.sub, np.subtract),
+    (operator.eq, np.equal),
+])
+def test_binary_operators(operator, numpy_function):
+    manager_name = pytest.config.getoption('backend', default='INTERPRETER')
+    runtime = ng.runtime(manager_name=manager_name)
+
+    value_a = np.array([[1, 2], [3, 4]], dtype=np.float32)
+    value_b = np.array([[5, 6], [7, 8]], dtype=np.float32)
+
+    shape = [2, 2]
+    parameter_a = ng.parameter(shape, name='A', dtype=np.float32)
+
+    model = operator(parameter_a, value_b)
+    computation = runtime.computation(model, parameter_a)
+
+    result = computation(value_a)
+    expected = numpy_function(value_a, value_b)
+    assert np.allclose(result, expected)
+
+
+@pytest.mark.parametrize('operator,numpy_function', [
+    (operator.add, np.add),
+    (operator.mul, np.multiply),
+    (operator.sub, np.subtract),
+    (operator.eq, np.equal),
+])
+def test_binary_operators_with_scalar(operator, numpy_function):
+    manager_name = pytest.config.getoption('backend', default='INTERPRETER')
+    runtime = ng.runtime(manager_name=manager_name)
+
+    value_a = np.array([[1, 2], [3, 4]], dtype=np.float32)
+    value_b = np.array([[5, 6], [7, 8]], dtype=np.float32)
+
+    shape = [2, 2]
+    parameter_a = ng.parameter(shape, name='A', dtype=np.float32)
+
+    model = operator(parameter_a, value_b)
     computation = runtime.computation(model, parameter_a)
 
     result = computation(value_a)


### PR DESCRIPTION
This is a proposal to support binary operators (`+`,`-`,`*`,`/`,`==`) on `Node` instances with scalar casting.

This makes it possible to do things like this:
```python
>>> import ngraph_api as ng
>>> my_param = ng.parameter((3,3))
>>> my_param == 5
<Equal: 'Equal_1'>
```
**Limitation**: This extends  the `Node` class at runtime, when the line `import ngraph_api as ng` is executed. That means that before executing that `import`, these operators are not in effect (they maintain their previous behavior with no scalar casting). 

This limitation could be removed, but in order to avoid circular imports, significant refactoring would be needed.


