### PR TITLE
Flake8-Bugbear requires Python3

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,4 +6,4 @@ flake8-commas
 flake8-comprehensions
 flake8-docstrings
 flake8-quotes
-flake8-bugbear
+

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
   -rrequirements.txt
   -rtest_requirements.txt
   mypy
+  flake8-bugbear
 commands=
   {envbindir}/python setup.py develop
   flake8 {posargs:pyngraph/ ngraph_api/ examples/}


### PR DESCRIPTION
Have to move `flake8-bugbear`, the common bugs detector, to Python 3 `tox` env only.