### PR TITLE
Fixing the default argument handling for serializer function

### DIFF
--- a/pyngraph/serializer.cpp
+++ b/pyngraph/serializer.cpp
@@ -24,6 +24,6 @@ namespace py = pybind11;
 void regclass_pyngraph_Serializer(py::module m) {
 
 
-    m.def("serialize", &ngraph::serialize);
+    m.def("serialize", &ngraph::serialize, py::arg(), py::arg("indent") = 0);
 
 }


### PR DESCRIPTION
With this fix, we can use `serialize` function in pyngraph to dump serialized graph.