### PR TITLE
skip failing gpu tests

### DIFF
--- a/tests/transformer_dependent/test_axes_transformer_dependent.py
+++ b/tests/transformer_dependent/test_axes_transformer_dependent.py
@@ -70,7 +70,7 @@ def test_idempotent_axes_b():
         assert cost_comp() == 6.0
         assert np.array_equal(grad_comp(), np.ones((3, 1)) * 2.)
 
-
+@pytest.config.nggpu_skip(reason="Not implemented")
 def test_idempotent_axes_c():
     """
     Test test axes transformations with autodiff, case c, with broadcast,

--- a/tests/transformer_dependent/test_dimshuffle_op.py
+++ b/tests/transformer_dependent/test_dimshuffle_op.py
@@ -8,7 +8,7 @@ import neon as ng
 
 pytestmark = pytest.mark.transformer_dependent
 
-
+@pytest.config.nggpu_skip(reason="Not implemented")
 def test_dimshuffle_op():
     A = ng.make_axis().named('A')
     B = ng.make_axis().named('B')

--- a/tests/transformer_dependent/test_dot.py
+++ b/tests/transformer_dependent/test_dot.py
@@ -98,6 +98,7 @@ def ngraph_l2_norm(np_array):
 
 
 @raise_all_numpy_errors
+@pytest.config.nggpu_skip(reason="Not implemented")
 def test_dot_sum_backprop():
     delta = 1e-3
     rtol = atol = 1e-2
@@ -163,6 +164,7 @@ def test_dot_sum_backprop():
 
 
 @raise_all_numpy_errors
+@pytest.config.nggpu_skip(reason="Not implemented")
 def test_tensor_dot_tensor():
     """TODO."""
     C = ng.make_axis().named('C')

--- a/tests/transformer_dependent/test_flatten.py
+++ b/tests/transformer_dependent/test_flatten.py
@@ -22,7 +22,7 @@ rng = RandomTensorGenerator(0, np.float32)
 
 pytestmark = pytest.mark.transformer_dependent
 
-
+@pytest.config.nggpu_skip(reason="Not implemented")
 def test_flatten_deriv_simplified():
     """
     Test derivative with dot and flatten

--- a/tests/transformer_dependent/test_kernel_generator.py
+++ b/tests/transformer_dependent/test_kernel_generator.py
@@ -39,7 +39,7 @@ def input_axes(request):
         ng.make_axis(length=request.param[3])
     ])
 
-
+@pytest.config.nggpu_skip(reason="Not implemented")
 def test_exit_condition(transformer_factory):
     bsz = 16
     class_num = 10

--- a/tests/transformer_dependent/test_op_graph_transformer_dependent.py
+++ b/tests/transformer_dependent/test_op_graph_transformer_dependent.py
@@ -162,7 +162,7 @@ def test_sequential_side(M):
         assert np.allclose(x1_final_val, x1_np)
         assert np.allclose(x2_final_val, x2_np)
 
-
+@pytest.config.nggpu_skip(reason="Not implemented")
 def test_concatenate(concatenate_variables):
     x_list, np_list, pos = concatenate_variables
 
@@ -177,6 +177,7 @@ def test_concatenate(concatenate_variables):
         ng.testing.assert_allclose(e_d.copy(), np.ones(x_list[0].axes.lengths))
 
 
+@pytest.config.nggpu_skip(reason="Not implemented")
 def test_concat_different_axis_lengths():
     ax1 = ng.make_axis(length=3, name="concat")
     ax2 = ng.make_axis(length=2, name="concat")
@@ -216,6 +217,7 @@ def test_initial_value():
     ng.testing.assert_allclose(result, np.asarray(w, dtype=np.float32))
 
 
+@pytest.config.nggpu_skip(reason="Not implemented")
 def test_multiple_computations():
     """
     Create multiple computations for the same value.

--- a/tests/transformer_dependent/test_pybind.py
+++ b/tests/transformer_dependent/test_pybind.py
@@ -168,7 +168,7 @@ def test_dot():
         # elementwise multiplication between scalar and vector
         assert np.allclose(_dot_val, _dot_val_ref)
 
-
+@pytest.config.nggpu_skip(reason="Not implemented")
 def test_prod():
 
     H = ng.make_axis(length=2)
@@ -221,6 +221,7 @@ def test_sum():
         assert np.array_equal(_sum_val, 10)
 
 
+@pytest.config.nggpu_skip(reason="Not implemented")
 def test_tensor_dot_tensor():
     """TODO."""
     C = ng.make_axis().named('C')
@@ -307,6 +308,8 @@ def test_tensor_dot_tensor():
     (ng.LessEqual, np.less_equal),
     (ng.power, np.power)
 ])
+
+@pytest.config.nggpu_skip(reason="Not implemented")
 def test_binary_op(ng_func, np_func):
     H = ng.make_axis().named('H')
     W = ng.make_axis().named('W')

--- a/tests/transformer_dependent/test_ssa.py
+++ b/tests/transformer_dependent/test_ssa.py
@@ -75,6 +75,7 @@ def test_modify_state():
         assert np.allclose(x_np + x_np, x_val)
 
 
+@pytest.config.nggpu_skip(reason="Not implemented")
 def test_concatenate():
     with ExecutorFactory() as ex:
         A = ng.make_axis(name='A', length=3)
@@ -90,7 +91,7 @@ def test_concatenate():
         j_val = f()
         ng.testing.assert_allclose(j_val, j_np)
 
-
+@pytest.config.nggpu_skip(reason="Not implemented")
 def test_specific_slice_deriv():
     #
     with ExecutorFactory() as ex:
@@ -113,6 +114,7 @@ def test_specific_slice_deriv():
                 ng.testing.assert_allclose(dslice_dx_val, dslice_dx_np)
 
 
+@pytest.config.nggpu_skip(reason="Not implemented")
 def test_slice_deriv():
     C = ng.make_axis(length=2)
     D = ng.make_axis(length=3)

--- a/tests/transformer_dependent/test_stack_tensor.py
+++ b/tests/transformer_dependent/test_stack_tensor.py
@@ -26,6 +26,7 @@ rtol = atol = 1e-2
 
 # Flex - Allowed to fail until PR2 - ref: 6714cc5
 @pytest.mark.transformer_dependent
+@pytest.config.nggpu_skip(reason="Not implemented")
 def test_stack():
     W = ng.make_axis(length=4)
     H = ng.make_axis(length=5)


### PR DESCRIPTION
some of the ngraph-neon unit tests are failing because ops are not supported on the gpu at this time, so skipping those tests.

This is a step towards adding gpu support to the ngraph-neon CI job